### PR TITLE
Add support for 2D graphs

### DIFF
--- a/utility/GraphHelper.hxx
+++ b/utility/GraphHelper.hxx
@@ -25,6 +25,9 @@
 #include <TGraphErrors.h>
 #include <TGraph2DErrors.h>
 #include <TGraphAsymmErrors.h>
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6,28,0)
+#include <TGraph2DAsymmErrors.h>
+#endif
 
 
 
@@ -224,7 +227,7 @@ namespace GraphHelper {
     private:
 
       // options for accessing specific members of a point
-      enum Member {X, Y, EX, EXlo, EXhi, EY, EYlo, EYhi};
+      enum Member {X, Y, Z, EX, EXlo, EXhi, EY, EYlo, EYhi, EZ, EZlo, EZhi};
 
       // data members
       std::string        m_name;
@@ -249,6 +252,10 @@ namespace GraphHelper {
               members.push_back(point.y);
               break;
 
+            case Member::Z:
+              members.push_back(point.z);
+              break;
+
             case Member::EX:
               members.push_back(point.ex);
               break;
@@ -271,6 +278,18 @@ namespace GraphHelper {
 
             case Member::EYhi:
               members.push_back(point.ey_hi);
+              break;
+
+            case Member::EZ:
+              members.push_back(point.ez);
+              break;
+
+            case Member::EZlo:
+              members.push_back(point.ez_lo);
+              break;
+
+            case Member::EZhi:
+              members.push_back(point.ez_hi);
               break;
 
             // by default return nothing
@@ -339,6 +358,28 @@ namespace GraphHelper {
       }  // end 'MakeTGraph()'
 
       // ----------------------------------------------------------------------
+      //! Make a TGraph2D
+      // ----------------------------------------------------------------------
+      TGraph2D* MakeTGraph2D() const {
+
+        // decompose points
+        std::vector<double> x_vals = GetMembers(Member::X);
+        std::vector<double> y_vals = GetMembers(Member::Y);
+        std::vector<double> z_vals = GetMembers(Member::Z);
+
+        // create graph
+        TGraph2D* graph = new TGraph2D(
+          m_points.size(),
+          x_vals.data(),
+          y_vals.data(),
+          z_vals.data()
+        );
+        graph -> SetName(m_name.data());
+        return graph;
+
+      }  // end 'MakeTGraph2D()'
+
+      // ----------------------------------------------------------------------
       //! Make a TGraphErrors
       // ----------------------------------------------------------------------
       TGraphErrors* MakeTGraphErrors() const {
@@ -361,6 +402,34 @@ namespace GraphHelper {
         return graph;
 
       }  // end 'MakeTGraphErrors()'
+
+      // ----------------------------------------------------------------------
+      //! Make a TGraph2DErrors
+      // ----------------------------------------------------------------------
+      TGraph2DErrors* MakeTGraph2DErrors() const {
+
+        // decompose points
+        std::vector<double> x_vals = GetMembers(Member::X);
+        std::vector<double> y_vals = GetMembers(Member::Y);
+        std::vector<double> z_vals = GetMembers(Member::Z);
+        std::vector<double> x_errs = GetMembers(Member::EX);
+        std::vector<double> y_errs = GetMembers(Member::EY);
+        std::vector<double> z_errs = GetMembers(Member::EZ);
+
+        // create graph
+        TGraph2DErrors* graph = new TGraph2DErrors(
+          m_points.size(),
+          x_vals.data(),
+          y_vals.data(),
+          z_vals.data(),
+          x_errs.data(),
+          y_errs.data(),
+          z_errs.data()
+        );
+        graph -> SetName(m_name.data());
+        return graph;
+
+      }  // end 'MakeTGraph2DErrors()'
 
       // ----------------------------------------------------------------------
       //! Make a TGraphAsymmErrors
@@ -389,6 +458,42 @@ namespace GraphHelper {
         return graph;
 
       }  // end 'MakeTGraphAsymmErrors()'
+
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6,28,0)
+      // ----------------------------------------------------------------------
+      //! Make a TGraph2DAsymmErrors
+      // ----------------------------------------------------------------------
+      TGraph2DAsymmErrors* MakeTGraph2DAsymmErrors() const {
+
+        // decompose points
+        std::vector<double> x_vals    = GetMembers(Member::X);
+        std::vector<double> y_vals    = GetMembers(Member::Y);
+        std::vector<double> z_vals    = GetMembers(Member::Z);
+        std::vector<double> x_lo_errs = GetMembers(Member::EXlo);
+        std::vector<double> x_hi_errs = GetMembers(Member::EXhi);
+        std::vector<double> y_lo_errs = GetMembers(Member::EYlo);
+        std::vector<double> y_hi_errs = GetMembers(Member::EYhi);
+        std::vector<double> z_lo_errs = GetMembers(Member::EZlo);
+        std::vector<double> z_hi_errs = GetMembers(Member::EZhi);
+
+        // create graph
+        TGraph2DAsymmErrors* graph = new TGraph2DAsymmErrors(
+          m_points.size(),
+          x_vals.data(),
+          y_vals.data(),
+          z_vals.data(),
+          x_lo_errs.data(),
+          x_hi_errs.data(),
+          y_lo_errs.data(),
+          y_hi_errs.data(),
+          z_lo_errs.data(),
+          z_hi_errs.data()
+        );
+        graph -> SetName(m_name.data());
+        return graph;
+
+      }  // end 'MakeTGraphAsymmErrors()'
+#endif
 
       // ----------------------------------------------------------------------
       //! default ctor/dtor


### PR DESCRIPTION
This PR implements support for 2D graphs in the `GraphHelper` namespace by back-propagating changes made downstream in [ROOTAnalysisUtilities](https://github.com/ruse-traveler/ROOTAnalysisUtilities).