### PR TITLE
Fix hit-merging arguments and retire ROOTFrameReader

### DIFF
--- a/generation/macros/CheckBHCalSimHitsEtaPhi.cxx
+++ b/generation/macros/CheckBHCalSimHitsEtaPhi.cxx
@@ -19,8 +19,8 @@
 #include <TSystem.h>
 // podio libraries
 #include <podio/Frame.h>
+#include <podio/ROOTReader.h>
 #include <podio/CollectionBase.h>
-#include <podio/ROOTFrameReader.h>
 // edm4eic types
 #include <edm4hep/SimCalorimeterHitCollection.h>
 // edm4hep types
@@ -59,7 +59,7 @@ void CheckBHCalSimHitsEtaPhi(const Options& opt = DefaultOptions) {
   // --------------------------------------------------------------------------
 
   // open file w/ frame reader
-  podio::ROOTFrameReader reader = podio::ROOTFrameReader();
+  podio::ROOTReader reader = podio::ROOTReader();
   reader.openFile( opt.in_file );
 
   // open output file

--- a/histograms/eicrecon/FillBHCalHitHistograms.cxx
+++ b/histograms/eicrecon/FillBHCalHitHistograms.cxx
@@ -22,8 +22,8 @@
 #include <TSystem.h>
 // podio libraries
 #include <podio/Frame.h>
+#include <podio/ROOTReader.h>
 #include <podio/CollectionBase.h>
-#include <podio/ROOTFrameReader.h>
 // edm4eic types
 #include <edm4eic/CalorimeterHitCollection.h>
 #include <edm4eic/ReconstructedParticleCollection.h>
@@ -65,7 +65,7 @@ void FillBHCalHitHistograms(const Options& opt = DefaultOptions) {
   // --------------------------------------------------------------------------
 
   // open file w/ frame reader
-  podio::ROOTFrameReader reader = podio::ROOTFrameReader();
+  podio::ROOTReader reader = podio::ROOTReader();
   reader.openFile( opt.in_file );
 
   // open output file

--- a/reconstruction/macros/FillBHCalClusterCalibrationTuple.cxx
+++ b/reconstruction/macros/FillBHCalClusterCalibrationTuple.cxx
@@ -23,8 +23,8 @@
 #include <TSystem.h>
 // podio libraries
 #include <podio/Frame.h>
+#include <podio/ROOTReader.h>
 #include <podio/CollectionBase.h>
-#include <podio/ROOTFrameReader.h>
 // edm4eic types
 #include <edm4eic/ClusterCollection.h>
 #include <edm4eic/CalorimeterHitCollection.h>
@@ -138,7 +138,7 @@ void FillBHCalClusterCalibrationTuple(const Options& opt = DefaultOptions) {
   // --------------------------------------------------------------------------
 
   // open file w/ frame reader
-  podio::ROOTFrameReader reader = podio::ROOTFrameReader();
+  podio::ROOTReader reader = podio::ROOTReader();
   reader.openFile( opt.in_file );
 
   // open output file

--- a/reconstruction/macros/FillBHCalOnlyTuple.cxx
+++ b/reconstruction/macros/FillBHCalOnlyTuple.cxx
@@ -17,8 +17,8 @@
 #include <TSystem.h>
 // podio libraries
 #include <podio/Frame.h>
+#include <podio/ROOTReader.h>
 #include <podio/CollectionBase.h>
-#include <podio/ROOTFrameReader.h>
 // edm4eic types
 #include <edm4eic/ClusterCollection.h>
 #include <edm4eic/CalorimeterHitCollection.h>
@@ -82,7 +82,7 @@ void FillBHCalOnlyTuple(const Options& opt = DefaultOptions) {
   // --------------------------------------------------------------------------
 
   // open file w/ frame reader
-  podio::ROOTFrameReader reader = podio::ROOTFrameReader();
+  podio::ROOTReader reader = podio::ROOTReader();
   reader.openFile( opt.in_file );
 
   // open output file

--- a/reconstruction/scripts/RunEICReconWithTileMerging.rb
+++ b/reconstruction/scripts/RunEICReconWithTileMerging.rb
@@ -24,18 +24,16 @@ END {
     "HcalBarrelRecHits",
     "HcalBarrelMergedHits",
     "HcalBarrelClusters",
-    "HcalBarrelSplitMergeClusters"
+    "HcalBarrelSplitMergeClusters",
+    "GeneratedParticles"
   ].compact.reject(&:empty?).join(',')
 
   # plugins to run in EICrecon
   plugins = [
-    "dump_flags"
   ].compact.reject(&:empty?).join(',')
 
   # options
   options = [
-  #  "-Pjana:nevents=100",
-    "-Peicrecon:LogLevel=trace"
   ].compact.reject(&:empty?).join(' ')
 
   # add relevant mapping/matrix
@@ -60,9 +58,9 @@ END {
 def make_phi_mapping(nmerge)
 
   map = if nmerge.to_i > 1
-    "\"phi-(#{nmerge}*((phi/#{nmerge})-floor(phi/#{nmerge})))\""
+    "\"phi:phi-(#{nmerge}*((phi/#{nmerge})-floor(phi/#{nmerge})))\""
   else
-    "phi"
+    "phi:phi"
   end
   return map
 


### PR DESCRIPTION
As the title says, this

- [x] fixes the arguments provided to EICrecon in the tile-merging script (they should have the form `field:transformation`),
- [x] and changes `ROOTFrameReader` to `ROOTReader` following our recent PODIO update. 